### PR TITLE
Quote text const correctly

### DIFF
--- a/capnpy/compiler/node.py
+++ b/capnpy/compiler/node.py
@@ -149,7 +149,7 @@ class Node__Const:
         pass
 
     def emit_reference_as_child(self, m):
-        # XXX: this works only for numerical consts so far
+        # XXX: this works only for numerical & text consts so far
         name = self.shortname(m)
         val = self.const.value.as_pyobj()
-        m.w("%s = %s" % (name, val))
+        m.w('{} = {!r}'.format(name, val))

--- a/capnpy/testing/compiler/test_compiler.py
+++ b/capnpy/testing/compiler/test_compiler.py
@@ -193,18 +193,22 @@ class TestCompilerOptions(CompilerTest):
         @0xbf5147cbbecf40c1;
         struct Foo {
             const bar :UInt16 = 42;
+            const baz :Text = "baz";
         }
         """
         mod = self.compile(schema)
         assert mod.Foo.bar == 42
+        assert mod.Foo.baz == b'baz'
 
     def test_global_const(self):
         schema = """
         @0xbf5147cbbecf40c1;
         const bar :UInt16 = 42;
+        const baz :Text = "baz";
         """
         mod = self.compile(schema)
         assert mod.bar == 42
+        assert mod.baz == b'baz'
 
 
 class TestCapnpExcecutable(CompilerTest):


### PR DESCRIPTION
It is not perfect, but at least it works for Python 2 with non unicode text