### PR TITLE
Fix nullable default & shortrepr

### DIFF
--- a/capnpy/compiler/field.py
+++ b/capnpy/compiler/field.py
@@ -203,16 +203,13 @@ class Field__Group:
         if nullable:
             nullable.check(m)
             ns.privname = '_' + name
-            ns.ww("""
-                @property
-                def {name}(self):
-                    g = self.{privname}
-                    if g.is_null:
-                        return None
-                    return g.value
+            m.def_property(ns, name, """
+                g = self.{privname}
+                if g.is_null:
+                    return None
+                return g.value
             """)
             name = ns.privname
-            ns.w()
         #
         m.def_property(ns, name, """
             {ensure_union}

--- a/capnpy/compiler/fieldtree.py
+++ b/capnpy/compiler/fieldtree.py
@@ -116,8 +116,12 @@ class Node(AbstractNode):
             self.default = str(default_val)
         else:
             assert self.f.is_group()
-            items = [child.default for child in self.children]
-            self.default = '(%s,)' % ', '.join(items)
+
+            if self.f.is_nullable(m):
+                self.default = 'None'
+            else:
+                items = [child.default for child in self.children]
+                self.default = '(%s,)' % ', '.join(items)
 
     def __repr__(self):
         return '<Node %s: %s>' % (self.varname, self.f.which())

--- a/capnpy/compiler/struct_.py
+++ b/capnpy/compiler/struct_.py
@@ -201,8 +201,15 @@ class Node__Struct:
             ns.w('parts = []')
             for f in fields:
                 ns.fname = m._field_name(f)
-                ns.fieldrepr = self._shortrepr_for_field(ns, f)
-                ns.append = ns.format('parts.append("{fname} = %s" % {fieldrepr})')
+                if f.is_nullable(m):
+                    assert f.is_group()
+                    f = m.allnodes[f.group.typeId].struct.fields[1]
+                    ns.fieldrepr = self._shortrepr_for_field(ns, f)
+                    ns.append = ns.format('parts.append("{fname} = %s" % ({fieldrepr} if self.{fname} is not None else None))')
+                else:
+                    ns.fieldrepr = self._shortrepr_for_field(ns, f)
+                    ns.append = ns.format('parts.append("{fname} = %s" % {fieldrepr})')
+
                 ns.is_default_field = bool(f.discriminantValue == 0)
                 #
                 if f.is_part_of_union() and f.is_pointer():

--- a/capnpy/struct_.py
+++ b/capnpy/struct_.py
@@ -230,7 +230,7 @@ class Struct(Blob):
     # hashing and equality
     # ----------------------
 
-    # in theory, this is the only method you nedd to override to enable
+    # in theory, this is the only method you need to override to enable
     # hashing and comparability. But in PYX mode, we override _hash and
     # _equals as well.
     def _key(self):

--- a/capnpy/testing/compiler/test_null.py
+++ b/capnpy/testing/compiler/test_null.py
@@ -115,6 +115,11 @@ class TestNullable(CompilerTest):
         assert not foo._x.is_null
         assert foo._x.value == 42
         assert foo.x == 42
+        #
+        foo = mod.Foo()
+        assert foo._x.is_null
+        assert foo._x.value == 0
+        assert foo.x is None
 
     def test_bad_nullable(self):
         schema = """

--- a/capnpy/testing/compiler/test_repr.py
+++ b/capnpy/testing/compiler/test_repr.py
@@ -283,3 +283,20 @@ class TestShortRepr(CompilerTest):
         p = self.mod.P.from_buffer(buf, 0, 1, 1)
         assert p.is_d()
         self.check(p, '(d = [])')
+
+    def test_null(self):
+        schema = """
+        @0xbf5147cbbecf40c1;
+        using Py = import "/capnpy/annotate.capnp";
+        struct Foo {
+            x :group $Py.nullable {
+                isNull @0 :Int8;
+                value  @1 :Int64;
+            }
+        }
+        """
+        self.mod = self.compile(schema)
+        foo = self.mod.Foo(None)
+        assert foo.shortrepr() == '(x = None)'
+        foo = self.mod.Foo(2)
+        assert foo.shortrepr() == '(x = 2)'


### PR DESCRIPTION
```
struct Foo {
   
	bar :group $Py.nullable {
		isNull @0 :Int8;
		value @1 :Float64;
	}
}
```

generate

```python
@staticmethod
def __new(bar=None):
    builder = _SegmentBuilder()
    pos = builder.allocate(16)
    if bar is None:
        bar_is_null = 1
        bar_value = 0
    else:
        bar_is_null = 0
        bar_value = bar
    builder.write_int8(pos + 0, bar_is_null)
    builder.write_float64(pos + 8, bar_value)
    return builder.as_string()

def __init__(self, bar=None):
    _buf = Foo.__new(bar)
    self._init_from_buffer(_buf, 0, 2, 0)

def shortrepr(self):
    parts = []
    parts.append("bar = %s" % (_float64_repr(self.bar) if self.bar is not None else None))
    return "(%s)" % ", ".join(parts)
```

So that

```
In [1]: Foo().shortrepr()
Out[1]: '(bar = None)'
In [2]: Foo(3).shortrepr()
Out[2]: '(bar = 3.0)'
```