### PR TITLE
Hack for import enum

### DIFF
--- a/capnpy/compiler/field.py
+++ b/capnpy/compiler/field.py
@@ -88,13 +88,24 @@ class Field__Slot:
     def _emit_enum(self, m, ns, name):
         ns.enumcls = self.slot.type.compile_name(m)
         ns.default_ = self.slot.defaultValue.as_pyobj()
-        m.def_property(ns, name, """
-            {ensure_union}
-            value = self._read_data_int16({offset})
-            if {default_} != 0:
-                value = (value ^ {default_})
-            return {enumcls}._new(value)
-        """)
+
+        node = self.slot.type.get_node(m)
+        if m.pyx and node.is_imported(m):
+            m.def_property(ns, name, """
+                {ensure_union}
+                value = self._read_data_int16({offset})
+                if {default_} != 0:
+                    value = (value ^ {default_})
+                return {enumcls}._new_hack(value)
+            """)
+        else:
+            m.def_property(ns, name, """
+                {ensure_union}
+                value = self._read_data_int16({offset})
+                if {default_} != 0:
+                    value = (value ^ {default_})
+                return {enumcls}._new(value)
+            """)
 
     def _emit_text(self, m, ns, name):
         ns.name = name

--- a/capnpy/compiler/module.py
+++ b/capnpy/compiler/module.py
@@ -121,6 +121,16 @@ class ModuleGenerator(object):
                         except IndexError:
                             return {name}(x)
                     """)
+
+                # The following is a hack so that other module can use it via import.
+                ns.w("@staticmethod")
+                with ns.block('def _new_hack(long x, __prebuilt={prebuilt}):') as ns:
+                    ns.ww("""
+                        try:
+                            return __prebuilt[x]
+                        except IndexError:
+                            return {name}(x)
+                    """)
             else:
                 # on PyPy, always create a new object, so that the JIT will be
                 # able to make it virtual

--- a/capnpy/testing/compiler/test_import.py
+++ b/capnpy/testing/compiler/test_import.py
@@ -50,6 +50,7 @@ class TestImport(CompilerTest):
             b @1 :P.Point;
             c @2 :List(P.Point);
             d @3 :List(P.Color);
+            e @4 :P.Color;
         }
         """)
         mod_tmp = comp.load_schema(importname="/tmp.capnp", pyx=self.pyx)
@@ -59,10 +60,11 @@ class TestImport(CompilerTest):
         b = mod_tmp._p_capnp.Point(3, 4)
         blue = mod_tmp._p_capnp.Color.blue
         yellow = mod_tmp._p_capnp.Color.yellow
-        rec = mod_tmp.Rectangle(a, b, c=[a, b], d=[blue, yellow])
+        rec = mod_tmp.Rectangle(a, b, c=[a, b], d=[blue, yellow], e=blue)
         assert rec.b.x == 3
         assert rec.c[1].x == 3
         assert rec.d[1] == yellow == 1
+        assert rec.e == blue
 
     def test_import_absolute(self):
         one = self.tmpdir.join('one').ensure(dir=True)


### PR DESCRIPTION
Fix #13 

Basically in pyx

A enum has 

```python
    @staticmethod
    cdef _new(long x, __prebuilt=(TestEnum(0), TestEnum(1),)):
        try:
            return __prebuilt[x]
        except IndexError:
            return TestEnum(x)
    @staticmethod
    def _new_hack(long x, __prebuilt=(TestEnum(0), TestEnum(1),)):
        try:
            return __prebuilt[x]
        except IndexError:
            return TestEnum(x)
```

And a caller would do

```python
    property test:
        def __get__(self):
            # no union check
            value = self._read_data_int16(0)
            if 0 != 0:
                value = (value ^ 0)
            return _schema_base_capnp.TestEnum._new_hack(value)
```

based on if the enum is imported or not