### PR TITLE
Check import paths are directories

### DIFF
--- a/capnpy/compiler/compiler.py
+++ b/capnpy/compiler/compiler.py
@@ -85,7 +85,8 @@ class BaseCompiler(object):
         # If <lang> is '-', the capnp compiler dumps the CodeGeneratorRequest bytes to standard output.
         cmd = ['capnp', 'compile', '-o-']
         for dirname in self.path:
-            cmd.append('-I%s' % dirname)
+            if os.path.isdir(str(dirname)):
+                cmd.append('-I%s' % dirname)
         cmd.append(str(filename))
         return self._exec(*cmd)
 


### PR DESCRIPTION
On my systems `sys.path` contains `/usr/lib/pythonX.zip`, where `X` is `27`, `35`, or `36` depending on Python version.

From `capnpc --help`:

```
    -I<dir>, --import-path=<dir>
        Add <dir> to the list of directories searched for non-relative imports
        (ones that start with a '/').
```

It seems reasonable to me to ignore `sys.path` entries that are not directories, especially because `capnpc` gets very unhappy if you pass it a file here!

```
will@desktop [19:59:19] [/tmp] 
-> % python3 -m capnpy compile example.capnp 
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.5/dist-packages/capnpy/__main__.py", line 65, in <module>
    main()
  File "/usr/local/lib/python3.5/dist-packages/capnpy/__main__.py", line 60, in main
    compile(args)
  File "/usr/local/lib/python3.5/dist-packages/capnpy/__main__.py", line 50, in compile
    version_check=args['--version-check'])
  File "/usr/local/lib/python3.5/dist-packages/capnpy/compiler/compiler.py", line 248, in compile
    m, src = self.generate_py_source(infile, convert_case, pyx, version_check)
  File "/usr/local/lib/python3.5/dist-packages/capnpy/compiler/compiler.py", line 56, in generate_py_source
    request = self._parse_schema_file(filename)
  File "/usr/local/lib/python3.5/dist-packages/capnpy/compiler/compiler.py", line 50, in _parse_schema_file
    data = self._capnp_compile(filename)
  File "/usr/local/lib/python3.5/dist-packages/capnpy/compiler/compiler.py", line 90, in _capnp_compile
    return self._exec(*cmd)
  File "/usr/local/lib/python3.5/dist-packages/capnpy/compiler/compiler.py", line 110, in _exec
    raise CompilerError(ensure_unicode(stderr))
capnpy.compiler.compiler.CompilerError: capnp compile: -I /usr/lib/python35.zip: no such directory
Try 'capnp compile --help' for more information.
```

Here's what `sys.path` looks like:

```
will@desktop [20:00:20] [/tmp] 
-> % python3
Python 3.5.2 (default, Nov 12 2018, 13:43:14) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.path
['', '/usr/lib/python35.zip', '/usr/lib/python3.5', '/usr/lib/python3.5/plat-x86_64-linux-gnu', '/usr/lib/python3.5/lib-dynload', '/home/will/.local/lib/python3.5/site-packages', '/usr/local/lib/python3.5/dist-packages', '/usr/lib/python3/dist-packages']
```