### PR TITLE
Work around unkown version of capnp

### DIFF
--- a/capnpy/compiler/compiler.py
+++ b/capnpy/compiler/compiler.py
@@ -104,6 +104,9 @@ class BaseCompiler(object):
         if not version.startswith("Cap'n Proto version"):
             raise CompilerError("capnp version string not recognized: %s" % version)
         _, version = version.rsplit(' ', 1)
+        if "unknown" in version:
+            # can't determine capnp version, continue with caution
+            return
         if version < LooseVersion('0.5.0'):
             raise CompilerError("The capnp executable is too old: the minimum required "
                                 "version is 0.5.0")


### PR DESCRIPTION
This seems to be caused by packaging problems in various distributions of capnproto, where `capnp --version` outputs `Cap'n Proto version (unknown)`.

Currently just a simple workaround for #18.  I believe the only other alternative would be to read capnp header files to get the version.