### PR TITLE
Fix group annotation collision bug

### DIFF
--- a/capnpy/compiler/field.py
+++ b/capnpy/compiler/field.py
@@ -57,7 +57,7 @@ class Field__Slot:
                                       self.slot.type.runtime_name(m))
 
     def _emit_void(self, m, ns, name):
-        field = m.field_override.get(self, None)
+        field = m.field_override.get(self.id, None)
         if field:
             field._emit(m, ns, name)
         else:

--- a/capnpy/compiler/module.py
+++ b/capnpy/compiler/module.py
@@ -51,7 +51,7 @@ class ModuleGenerator(object):
         self.extra_annotations[obj].append(ann.annotation)
 
     def register_field_override(self, origin, target):
-        self.field_override[origin] = target
+        self.field_override[origin.id] = target
 
     def has_annotation(self, obj, anncls):
         try:

--- a/capnpy/compiler/request.py
+++ b/capnpy/compiler/request.py
@@ -14,7 +14,7 @@ def find_all_py_group_fields(m):
         if not v.is_struct():
             continue
 
-        for field in v.struct.fields or []:
+        for field in v.get_struct_fields() or []:
             ann = m.has_annotation(field, annotate.group)
             if ann:
                 ann.check(m)

--- a/capnpy/compiler/struct_.py
+++ b/capnpy/compiler/struct_.py
@@ -30,12 +30,12 @@ class Node__Struct:
         # find and register all groups having a $key annotation. We need to do
         # it here because we need this info when we emit the definition for
         # the group class
-        for field in self.struct.fields or []:
+        for field in self.get_struct_fields() or []:
             ann = m.has_annotation(field, annotate.key)
             if ann:
                 if field.is_void():
                     # Register the fake node_group.
-                    field = m.field_override[field]
+                    field = m.field_override[field.id]
                 assert field.is_group()
                 group_node = field.group.get_node(m)
                 m.register_extra_annotation(group_node, ann)


### PR DESCRIPTION
We were storing field overrides by name and code order, which is
not unique and led to group annotations being applied incorrectly.
Solution is to use the ID of the field instead.