### PR TITLE
Fix `repr` for non-textual data fields

### DIFF
--- a/capnpy/compiler/request.py
+++ b/capnpy/compiler/request.py
@@ -68,6 +68,7 @@ class RequestedFile:
         m.w("from capnpy.anypointer import AnyPointer as _AnyPointer")
         m.w("from capnpy.util import text_bytes_repr as _text_bytes_repr")
         m.w("from capnpy.util import text_unicode_repr as _text_unicode_repr")
+        m.w("from capnpy.util import data_repr as _data_repr")
         m.w("from capnpy.util import float32_repr as _float32_repr")
         m.w("from capnpy.util import float64_repr as _float64_repr")
         m.w("from capnpy.util import extend_module_maybe as _extend_module_maybe")

--- a/capnpy/compiler/struct_.py
+++ b/capnpy/compiler/struct_.py
@@ -258,10 +258,12 @@ class Node__Struct:
             return ns.format('str(self.{pyname}).lower()')
         elif f.is_void():
             return '"void"'
-        elif f.is_text_bytes(m) or f.is_data():
+        elif f.is_text_bytes(m):
             return ns.format('_text_bytes_repr(self.get_{pyname}())')
         elif f.is_text_unicode(m):
             return ns.format('_text_unicode_repr(self.get_{pyname}())')
+        elif f.is_data():
+            return ns.format('_data_repr(self.get_{pyname}())')
         elif f.is_struct() or f.is_list():
             return ns.format('self.get_{pyname}().shortrepr()')
         elif f.is_group():

--- a/capnpy/util.py
+++ b/capnpy/util.py
@@ -86,16 +86,32 @@ def check_version(modname, version):
         raise ImportError(msg)
 
 def text_bytes_repr(s):
-    s = decode_maybe(s)
+    return text_unicode_repr(decode_maybe(s))
+
+def text_unicode_repr(s):
     s = s.replace('"', r'\"')
     s = s.replace("'", r"\'")
     return u'"%s"' % s
 
-def text_unicode_repr(s):
-    return text_bytes_repr(encode_maybe(s))
+def data_repr(s):
+    s = s.decode('utf-8', errors='backslashreplace')
+    return text_unicode_repr(s)
 
 
 try:
     from capnpy.floatrepr import float32_repr, float64_repr
 except ImportError:
     float32_repr = float64_repr = repr
+
+
+if six.PY2:
+    import codecs
+    _bytes_repr = lambda c: '\\x{:x}'.format(ord(c))
+    _text_repr = lambda c: ('\\U{:08x}' if ord(c) >= 0x10000 else '\\u{:04x}').format(ord(c))
+
+    def backslashreplace(ex):
+        c_repr = _bytes_repr if isinstance(ex, UnicodeDecodeError) else _text_repr
+        return u''.join(c_repr(c) for c in ex.object[ex.start:ex.end]), ex.end
+
+    # Define an error handler equivalent to that provided in Python 3.5+
+    codecs.register_error('backslashreplace', backslashreplace)


### PR DESCRIPTION
- Adds an extra stage to 'test_repr' to try encoding the output
`repr` string using `capnp`
- Fixes inconsistencies in `test_union_set_but_null_pointer`
detected by the previous change
- Defines a full 'backslashreplace' error handler for Python 2.7
- `repr`s data using unicode-friendly escape sequences