### PR TITLE
fix capnp issue with schema absolute path

### DIFF
--- a/capnpy/compiler/compiler.py
+++ b/capnpy/compiler/compiler.py
@@ -94,11 +94,7 @@ class BaseCompiler(object):
                                 "installed and in $PATH")
         self._capnp_check_version()
         # If <lang> is '-', the capnp compiler dumps the CodeGeneratorRequest bytes to standard output.
-        cmd = ['capnp', 'compile', '-o-']
-        for dirname in self.path:
-            if dirname.isdir():
-                cmd.append('-I%s' % dirname)
-        cmd.append(str(filename))
+        cmd = ['capnp', 'compile', '-o-', '-I/', str(filename)]
         return self._exec(*cmd)
 
     def _capnp_check_version(self):

--- a/capnpy/compiler/compiler.py
+++ b/capnpy/compiler/compiler.py
@@ -35,7 +35,7 @@ class BaseCompiler(object):
     include_dirs = [str(PKGDIR)] # include "ptr.h"
 
     def __init__(self, path):
-        self.path = [py.path.local(dirname) for dirname in path]
+        self.path = [py.path.local(dirname) for dirname in path + ['/']]
         self.capnproto_version = None
         self._tmpdir = None
 
@@ -94,7 +94,11 @@ class BaseCompiler(object):
                                 "installed and in $PATH")
         self._capnp_check_version()
         # If <lang> is '-', the capnp compiler dumps the CodeGeneratorRequest bytes to standard output.
-        cmd = ['capnp', 'compile', '-o-', '-I/', str(filename)]
+        cmd = ['capnp', 'compile', '-o-']
+        for dirname in self.path:
+            if dirname.isdir():
+                cmd.append('-I%s' % dirname)
+        cmd.append(str(filename))
         return self._exec(*cmd)
 
     def _capnp_check_version(self):


### PR DESCRIPTION
As defined [here](https://capnproto.org/language.html),

`If the path begins with a /, it is absolute – in this case, the capnp tool searches for the file in each of the search path directories specified with -I.`

This doesn't quite make sense, but if you specify an absolute path you need to specify the directory to search, in this case is simply `/`. Without including `/` it may compile a schema file that doesn't import any other, but if your schema imports another using an absolute path it will fail to find it without including the root `/`.

For example, if you have file at `/home/shane/log.capnp` that imports another using an absolute path, the following command doesn't work: `capnp compile /home/shane/log.capnp`. You need to include `/` and only then it compiles and finds the imported file: `capnp compile /home/shane/log.capnp -I/`

Working with capnp 0.8.0. I'm not sure if we also need the paths in `self.path` or not.