### PR TITLE
Use Github actions instead of travis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,18 +16,16 @@ env:
 
 jobs:
   main_tests:
-    name: Main tests
-    runs-on: ${{ matrix.os }}
+    name: tox ${{ matrix.TOXENV }}
+
+    runs-on: ubunu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
         include:
           - python-version: '3.7'
-            env:
-              TOXENV: py37-test
+            TOXENV: py37-test
           - python-version: '3.8'
-            env:
-              TOXENV: py38-test
+            TOXENV: py38-test
 
     steps:
       - uses: actions/checkout@v2
@@ -60,5 +58,5 @@ jobs:
         run: |
           echo "fake run tox"
           python --version
-          echo "TOXENV: ${TOXENV}"
+          echo "TOXENV: ${{ TOXENV }}"
           env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # include:
-        #   - python-version: '3.7'
         include:
+          - python-version: '3.7'
+            env:
+              TOXENV: py37-test
           - python-version: '3.8'
+            env:
+              TOXENV: py38-test
 
     steps:
       - uses: actions/checkout@v2
@@ -50,6 +53,4 @@ jobs:
           pip install tox cython>=0.25
 
       - name: Run tox
-        env:
-          TOXENV: py38-test
         run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@
 name: tests
 on: [push, pull_request]
 
+env:
+  CAPNPROTO=capnproto-c++-0.7.0
+
 jobs:
   main_tests:
     name: Main tests
@@ -23,9 +26,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Setting up build environment
+      - name: Cache capnproto
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-capnproto
+        with:
+          path: ~/capnproto
+          key: ${{ runner.os }}-${{ env.CAPNPROTO }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.CAPNPROTO }}
+
+      - name: Install capnproto
+        run: bash ./ci/install_capnp.sh
+
+      - name: pip install
         run: |
-          bash ./travis/install_capnp.sh
           pip install -U pip # so that we can use wheels
           # tox creates the sdist: we need cython to be installed in the env which
           # creates the sdist, to generate the .c files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,8 @@ name: tests
 on: [push, pull_request]
 
 env:
-  - LD_LIBRARY_PATH: "$HOME/capnp/lib"
+  CAPNP_DIR: /opt/capnp
+  LD_LIBRARY_PATH: /opt/capnp/lib
 
 jobs:
   main_tests:
@@ -28,7 +29,7 @@ jobs:
 
       - name: Setting up build environment
         run: |
-          echo "$HOME/capnp/bin" >> $GITHUB_PATH
+          echo "$CAPNP_DIR/bin" >> $GITHUB_PATH
           bash ./travis/install_capnp.sh
           pip install -U pip # so that we can use wheels
           # tox creates the sdist: we need cython to be installed in the env which

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
   main_tests:
     name: Main tests
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,6 @@
 name: tests
 on: [push, pull_request]
 
-env:
-  CAPNP_DIR: /opt/capnp
-  LD_LIBRARY_PATH: /opt/capnp/lib
-
 jobs:
   main_tests:
     name: Main tests
@@ -29,7 +25,6 @@ jobs:
 
       - name: Setting up build environment
         run: |
-          echo "$CAPNP_DIR/bin" >> $GITHUB_PATH
           bash ./travis/install_capnp.sh
           pip install -U pip # so that we can use wheels
           # tox creates the sdist: we need cython to be installed in the env which

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           pip install -U pip # so that we can use wheels
           # tox creates the sdist: we need cython to be installed in the env which
           # creates the sdist, to generate the .c files
-          pip install cython>=0.25
+          pip install tox cython>=0.25
 
       - name: Run tox
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,17 +16,32 @@ env:
 
 jobs:
   tox_tests:
-    name: tox -e ${{ matrix.python-version }}
+    name: tox -e ${{ matrix.toxenv }}
 
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
+          - python-version: '2.7'
+            toxenv: 'nopyx-test'
+
+          - python-version: '2.7'
+            toxenv: 'py27-test'
+
+          - python-version: '3.5'
+            toxenv: 'py35-test'
+
+          - python-version: '3.6'
+            toxenv: 'py36-test'
+
           - python-version: '3.7'
             toxenv: 'py37-test'
 
           - python-version: '3.8'
             toxenv: 'py38-test'
+
+          - python-version: 'pypy-3.7'
+            toxenv: 'pypy3-test'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 ---
 name: tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 env:
   CAPNPROTO: capnproto-c++-0.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,7 @@ jobs:
       matrix:
         include:
           - python-version: '3.7'
-            TOXENV: py37-test
           - python-version: '3.8'
-            TOXENV: py38-test
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           path: ~/capnproto
           key: ${{ runner.os }}-${{ env.CAPNPROTO }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.CAPNPROTO }}
 
       - name: Install capnproto
         run: bash ./ci/install_capnp.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: ubuntu-latest
+        os: [ubuntu-latest]
         # include:
         #   - python-version: '3.7'
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ env:
   CAPNPROTO: capnproto-c++-0.7.0
 
 jobs:
-  main_tests:
+  tox_tests:
     name: tox ${{ matrix.python-version }}
 
-    runs-on: ubunu-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,15 @@
 ---
 name: tests
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
+
+on: [push]
+
+# on:
+#   push:
+#     branches:
+#     - master
+#   pull_request:
+#     branches:
+#     - master
 
 env:
   CAPNPROTO: capnproto-c++-0.7.0
@@ -53,4 +56,9 @@ jobs:
           pip install tox cython>=0.25
 
       - name: Run tox
-        run: tox
+        #run: tox
+        run: |
+          echo "fake run tox"
+          python --version
+          echo "TOXENV: ${TOXENV}"
+          env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           cache-name: cache-capnproto
         with:
           path: ~/capnproto
-          key: ${{ runner.os }}-${{ env.CAPNPROTO }}
+          key: ${{ env.CAPNPROTO }}-${{ runner.os }}
 
       - name: Install capnproto
         run: bash ./ci/install_capnp.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,4 @@ jobs:
         run: |
           echo "fake run tox"
           python --version
-          env
+          echo "matrix.foo: {{ matrix.foo }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,9 @@ jobs:
       matrix:
         include:
           - python-version: '3.7'
-            env:
-              TOXENV: py37-test
+            foo: '37'
           - python-version: '3.8'
-            env:
-              TOXENV: py38-test
+            foo: '38'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,11 @@ jobs:
       matrix:
         include:
           - python-version: '3.7'
+            env:
+              TOXENV: py37-test
           - python-version: '3.8'
+            env:
+              TOXENV: py38-test
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,13 @@
 ---
 name: tests
 
-on: [push]
-
-# on:
-#   push:
-#     branches:
-#     - master
-#   pull_request:
-#     branches:
-#     - master
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 env:
   CAPNPROTO: capnproto-c++-0.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+---
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  main_tests:
+    name: Main tests
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        os: ubuntu-latest
+        # include:
+        #   - python-version: '3.7'
+        include:
+          - python-version: '3.8'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setting up build environment
+        run: |
+          bash ./travis/install_capnp.sh
+          pip install -U pip # so that we can use wheels
+          # tox creates the sdist: we need cython to be installed in the env which
+          # creates the sdist, to generate the .c files
+          pip install cython>=0.25
+
+      - name: Run tox
+        env:
+          TOXENV: py38-test
+        run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
           - python-version: '2.7'
             toxenv: 'py27-test'
 
-          - python-version: '3.5'
-            toxenv: 'py35-test'
-
           - python-version: '3.6'
             toxenv: 'py36-test'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,5 +56,4 @@ jobs:
         run: |
           echo "fake run tox"
           python --version
-          #echo "TOXENV: ${{ TOXENV }}"
           env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,17 @@ env:
 
 jobs:
   tox_tests:
-    name: tox ${{ matrix.python-version }}
+    name: tox -e ${{ matrix.python-version }}
 
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - python-version: '3.7'
-            foo: '37'
+            toxenv: 'py37-test'
+
           - python-version: '3.8'
-            foo: '38'
+            toxenv: 'py38-test'
 
     steps:
       - uses: actions/checkout@v2
@@ -54,8 +55,4 @@ jobs:
           pip install tox cython>=0.25
 
       - name: Run tox
-        #run: tox
-        run: |
-          echo "fake run tox"
-          python --version
-          echo "matrix.foo: ${{ matrix.foo }}"
+        run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   main_tests:
-    name: tox ${{ matrix.TOXENV }}
+    name: tox ${{ matrix.python-version }}
 
     runs-on: ubunu-latest
     strategy:
@@ -56,5 +56,5 @@ jobs:
         run: |
           echo "fake run tox"
           python --version
-          echo "TOXENV: ${{ TOXENV }}"
+          #echo "TOXENV: ${{ TOXENV }}"
           env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,4 @@ jobs:
         run: |
           echo "fake run tox"
           python --version
-          echo "matrix.foo: {{ matrix.foo }}"
+          echo "matrix.foo: ${{ matrix.foo }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: tests
 on: [push, pull_request]
 
 env:
-  CAPNPROTO=capnproto-c++-0.7.0
+  CAPNPROTO: capnproto-c++-0.7.0
 
 jobs:
   main_tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 ---
 name: tests
-
 on: [push, pull_request]
+
+env:
+  - LD_LIBRARY_PATH: "$HOME/capnp/lib"
 
 jobs:
   main_tests:
@@ -26,6 +28,7 @@ jobs:
 
       - name: Setting up build environment
         run: |
+          echo "$HOME/capnp/bin" >> $GITHUB_PATH
           bash ./travis/install_capnp.sh
           pip install -U pip # so that we can use wheels
           # tox creates the sdist: we need cython to be installed in the env which

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 capnpy
 ======
 
-.. image:: https://travis-ci.org/antocuni/capnpy.svg?branch=master
-    :target: https://travis-ci.org/antocuni/capnpy
+.. image:: https://github.com/antocuni/capnpy/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/antocuni/capnpy/actions/workflows/test.yml
 
 A very fast implementation of `Cap’n Proto`_ for CPython and PyPy.
 

--- a/capnpy/__init__.py
+++ b/capnpy/__init__.py
@@ -1,5 +1,5 @@
 import sys
-import pkg_resources
+#import pkg_resources
 
 from capnpy.compiler.compiler import DynamicCompiler
 from capnpy.compiler.distutils import capnpify

--- a/ci/install_capnp.sh
+++ b/ci/install_capnp.sh
@@ -3,8 +3,9 @@ set -e
 
 # $CAPNPROTO is defined by test.yml env
 
-if [ ! -d capnproto ]; then
+if [ ! -d ~/capnproto ]; then
     echo 'Compiling capnproto'
+    cd
     curl -O https://capnproto.org/$CAPNPROTO.tar.gz
     tar zxf $CAPNPROTO.tar.gz
     mv $CAPNPROTO capnproto
@@ -13,7 +14,7 @@ if [ ! -d capnproto ]; then
     make -j8
 else
     echo 'Using cached capnproto'
-    cd capnproto
+    cd ~/capnproto
 fi
 
 sudo make install

--- a/ci/install_capnp.sh
+++ b/ci/install_capnp.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# $CAPNPROTO is defined by test.yml env
+
+if [ ! -d capnproto ]; then
+    echo 'Compiling capnproto'
+    curl -O https://capnproto.org/$CAPNPROTO.tar.gz
+    tar zxf $CAPNPROTO.tar.gz
+    mv $CAPNPROTO capnproto
+    cd capnproto
+    ./configure
+    make -j8
+else
+    echo 'Using cached capnproto'
+    cd capnproto
+fi
+
+sudo make install
+capnp --version

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ setup(name="capnpy",
       packages=find_packages(),
       ext_modules=ext_modules,
       install_requires=['pypytools>=0.3.3', 'docopt', 'six'] + extra_install_requires,
-      setup_requires=['setuptools_scm'],
+      setup_requires=['setuptools_scm==5.0.2'],
       zip_safe=False,
       entry_points={
           "distutils.setup_keywords": [

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ setenv =
 deps =
     pytest==2.8.2
     git+https://github.com/antocuni/pytest-benchmark.git#egg=pytest-benchmark
+    py27: pkgconfig==1.5.2
     py27: pycapnp
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest==2.8.2
     git+https://github.com/antocuni/pytest-benchmark.git#egg=pytest-benchmark
     py27: pkgconfig==1.5.2
-    py27: pycapnp
+    py27: pycapnp==0.6.4
 
 commands =
     test: py.test {envsitepackagesdir}/capnpy/testing -rs --pyx {posargs}

--- a/travis/install_capnp.sh
+++ b/travis/install_capnp.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 set -e
 
-if [ ! -d "$CAPNP_DIR/lib" ]; then
+CAPNPROTO=capnproto-c++-0.7.0
+
+if [ ! -d "$CAPNPROTO" ]; then
     echo 'Compiling capnproto'
-    CAPNPROTO=capnproto-c++-0.7.0
     curl -O https://capnproto.org/$CAPNPROTO.tar.gz
     tar zxf $CAPNPROTO.tar.gz
     cd $CAPNPROTO
-    ./configure --prefix=$CAPNP_DIR/lib
+    ./configure
     make -j3
-    make install
 else
     echo 'Using cached capnproto'
+    cd $CAPNPROTO
 fi
+
+sudo make install
 capnp --version

--- a/travis/install_capnp.sh
+++ b/travis/install_capnp.sh
@@ -3,6 +3,7 @@ set -e
 
 CAPNPROTO=capnproto-c++-0.7.0
 
+cd
 if [ ! -d "$CAPNPROTO" ]; then
     echo 'Compiling capnproto'
     curl -O https://capnproto.org/$CAPNPROTO.tar.gz

--- a/travis/install_capnp.sh
+++ b/travis/install_capnp.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-if [ ! -d "$HOME/capnp/lib" ]; then
+if [ ! -d "$CAPNP_DIR/lib" ]; then
     echo 'Compiling capnproto'
     CAPNPROTO=capnproto-c++-0.7.0
     curl -O https://capnproto.org/$CAPNPROTO.tar.gz
     tar zxf $CAPNPROTO.tar.gz
     cd $CAPNPROTO
-    ./configure --prefix=$HOME/capnp
+    ./configure --prefix=$CAPNP_DIR/lib
     make -j3
     make install
 else

--- a/travis/install_capnp.sh
+++ b/travis/install_capnp.sh
@@ -1,20 +1,16 @@
 #!/bin/bash
 set -e
 
-CAPNPROTO=capnproto-c++-0.7.0
-
-cd
-if [ ! -d "$CAPNPROTO" ]; then
+if [ ! -d "$HOME/capnp/lib" ]; then
     echo 'Compiling capnproto'
+    CAPNPROTO=capnproto-c++-0.7.0
     curl -O https://capnproto.org/$CAPNPROTO.tar.gz
     tar zxf $CAPNPROTO.tar.gz
     cd $CAPNPROTO
-    ./configure
+    ./configure --prefix=$HOME/capnp
     make -j3
+    make install
 else
     echo 'Using cached capnproto'
-    cd $CAPNPROTO
 fi
-
-sudo make install
 capnp --version


### PR DESCRIPTION
Run tox tests in github actions.

Note that the following functionalities were supported by travis, but they have not been ported to GHA yet:
- running benchmarks
- build docs
- automatic build+deploy of releases