### PR TITLE
Automatically build&publish wheels on release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,13 @@
 ---
 name: tests
 
-# XXX temporary: disable tests for now in this PR
 on:
   push:
     branches:
     - master
-  # pull_request:
-  #   branches:
-  #   - master
+  pull_request:
+    branches:
+    - master
 
 env:
   CAPNPROTO: capnproto-c++-0.7.0


### PR DESCRIPTION
Add a github actions workflow to build wheels (using cibuildwheels) and upload them to PyPI whenever we create a github release.

Currently we build wheels only for CPython 3.6, 3.7, 3.8, 3.9 and 3.10.
Python 2.7 is tested and supported but we don't publish a wheel because the current version of cibuildwheels doesn't support it.
PyPy is tested and supported but we don't publish wheels because we don't use cython, so installing from source is fast.