### PR TITLE
WIP: Python 3.11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
           - python-version: '3.10'
             toxenv: 'py310-test'
 
+          - python-version: '3.11.0-alpha - 3.11' # SemVer's version range syntax
+            toxenv: 'py311-test'
+
           - python-version: 'pypy-3.7'
             toxenv: 'pypy3-test'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # these are the files produced by cython when building inplace
 capnpy/*.c
 capnpy/*.html
+capnpy/*.so
 capnpy/segment/*.c
 capnpy/segment/*.html
+capnpy/segment/*.so
+capnpy.egg-info
 travis/travis.rsa
+
+build
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
   - pip install tox-travis
   # tox creates the sdist: we need cython to be installed in the env which
   # creates the sdist, to generate the .c files
-  - pip install cython>=0.25
+  - pip install cython>=0.29.30
 
 script:
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./travis/clone-benchmarks-repo.sh; fi

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ else:
 
 if USE_CYTHON:
     ext_modules = get_cython_extensions()
-    extra_install_requires = ['cython>=0.25']
+    extra_install_requires = ['cython>=0.29.30']
 else:
     ext_modules = []
     extra_install_requires = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # nopyx is a special env where Cython is NOT installed, and thus we run
 # pure-python tests
-envlist = py27-test-nopyx,py27-{test,bench},py35-test,py36-test,py37-test,py38-test,py39-test,[y310-test,pypy-{test,bench},pypy3-{test},docs
+envlist = py27-test-nopyx,py27-{test,bench},py35-test,py36-test,py37-test,py38-test,py39-test,py310-test,py311-test,pypy-{test,bench},pypy3-{test},docs
 
 [testenv]
 setenv =

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -13,7 +13,7 @@ PYTHONS=(
 
 for pydir in "${PYTHONS[@]}"; do
     pybin=/opt/python/$pydir/bin
-    "${pybin}/pip" install 'cython>=0.25'
+    "${pybin}/pip" install 'cython>=0.29.30'
     "${pybin}/pip" wheel /capnpy/ -w wheelhouse/
 
     # workaround for this bug:


### PR DESCRIPTION
I opened this PR to check whether capnpy is compatible with python3.11, but it turns out that there are at least two problems:

1. tox seems to crash; [github action output](https://github.com/antocuni/capnpy/pull/58/checks?check_run_id=3941610094):
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.0-alpha.1/x64/lib/python3.11/site-packages/py/_vendored_packages/apipkg/__init__.py", line 145, in __makeattr
    modpath, attrname = self.__map__[name]
                        ~~~~~~~~~~~~^^^^^^
KeyError: '__spec__'
```

2. I tried to compile it manually on my machine and stumbled upon this Cython issue: https://github.com/cython/cython/issues/4365