### PR TITLE
Increase the minimum cython version to 0.29.30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # these are the files produced by cython when building inplace
 capnpy/*.c
 capnpy/*.html
+capnpy/*.so
 capnpy/segment/*.c
 capnpy/segment/*.html
+capnpy/segment/*.so
+capnpy.egg-info
 travis/travis.rsa
+
+build
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
   - pip install tox-travis
   # tox creates the sdist: we need cython to be installed in the env which
   # creates the sdist, to generate the .c files
-  - pip install cython>=0.25
+  - pip install cython>=0.29.30
 
 script:
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./travis/clone-benchmarks-repo.sh; fi

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ else:
 
 if USE_CYTHON:
     ext_modules = get_cython_extensions()
-    extra_install_requires = ['cython>=0.25']
+    extra_install_requires = ['cython>=0.29.30']
 else:
     ext_modules = []
     extra_install_requires = []

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -13,7 +13,7 @@ PYTHONS=(
 
 for pydir in "${PYTHONS[@]}"; do
     pybin=/opt/python/$pydir/bin
-    "${pybin}/pip" install 'cython>=0.25'
+    "${pybin}/pip" install 'cython>=0.29.30'
     "${pybin}/pip" wheel /capnpy/ -w wheelhouse/
 
     # workaround for this bug:


### PR DESCRIPTION
This increases the minimum cython version to `0.29.30` to make the build work under python 3.11.