### PR TITLE
WIP: Default bytes behind end of segment to 0

### DIFF
--- a/capnpy/segment/base.py
+++ b/capnpy/segment/base.py
@@ -38,7 +38,8 @@ class BaseSegment(object):
     def read_primitive(self, offset, ifmt):
         fmt = b'<' + mychr(ifmt)
         if offset < 0 or offset + struct.calcsize(fmt) > len(self.buf):
-            raise IndexError('Offset out of bounds: %d' % offset)
+            return 0
+            # raise IndexError('Offset out of bounds: %d' % offset)
         return struct.unpack_from(fmt, self.buf, offset)[0]
 
     def read_int64(self, offset):

--- a/capnpy/segment/base.pyx
+++ b/capnpy/segment/base.pyx
@@ -42,7 +42,8 @@ cdef class BaseSegment(object):
         # *not* do the check.
         cdef Py_ssize_t buflen = _PyString_GET_SIZE(self.buf)
         if offset < 0 or offset + size > buflen:
-            raise IndexError('Offset out of bounds: %d' % (offset+size))
+            return 0
+            # raise IndexError('Offset out of bounds: %d' % (offset+size))
 
     @cython.final
     cdef object read_primitive(self, Py_ssize_t offset, char ifmt):

--- a/capnpy/struct_.py
+++ b/capnpy/struct_.py
@@ -56,8 +56,8 @@ class Struct(Blob):
         self._ptrs_offset = offset + data_size*8
         self._data_size = data_size
         self._ptrs_size = ptrs_size
-        assert self._data_offset + data_size*8 <= len(self._seg.buf)
-        assert self._ptrs_offset + ptrs_size*8 <= len(self._seg.buf)
+        # assert self._data_offset + data_size*8 <= len(self._seg.buf)
+        # assert self._ptrs_offset + ptrs_size*8 <= len(self._seg.buf)
 
     def _init_from_pointer(self, buf, offset, p):
         assert ptr.kind(p) == ptr.STRUCT
@@ -179,12 +179,12 @@ class Struct(Blob):
 
     def _read_fast_ptr(self, offset):
         # Struct-specific logic
-        if offset >= self._ptrs_size*8:
+        if offset >= (self._data_size + self._ptrs_size)*8:
             return 0
         return self._seg.read_ptr(self._ptrs_offset+offset)
 
     def _read_far_ptr(self, offset):
-        if offset >= self._ptrs_size*8:
+        if offset >= (self._data_size + self._ptrs_size)*8:
             return offset, 0
         return self._seg.read_far_ptr(self._ptrs_offset+offset)
 


### PR DESCRIPTION
The capnp documentation implies this is the correct behaviour and without this commit asserts would fail on structs encoded with the C++ encoder.

However, at this moment, this commit is just a suggestion for the purpose of a discussion, before proceeding it requires a cleanup and new tests.