### PR TITLE
github actions: update upload-artifact to v4

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install/Upgrade Python dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        python -m pip install cython==0.29.36
+        python -m pip install cython>=0.29.36
 
     - name: Build and install Python source package
       run: |
@@ -52,7 +52,7 @@ jobs:
     - name: Build wheels for CPython
       uses: pypa/cibuildwheel@v2.14.1
       env:
-        CIBW_BEFORE_BUILD: 'pip install cython==0.29.36'
+        CIBW_BEFORE_BUILD: 'pip install cython>=0.29.36'
         CIBW_BUILD: 'cp*'     # build all CPython versions
         #CIBW_SKIP: 'cp310-*' #
         CIBW_ARCHS: 'auto64'  # only 64-bit

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -24,7 +24,7 @@ jobs:
         python setup.py sdist
         python -m pip install dist/*.tar.gz
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         path: dist/*.tar.gz
 
@@ -57,7 +57,7 @@ jobs:
         #CIBW_SKIP: 'cp310-*' #
         CIBW_ARCHS: 'auto64'  # only 64-bit
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
 


### PR DESCRIPTION
To fix the error:

[Build binary wheels (ubuntu-latest)](https://github.com/antocuni/capnpy/actions/runs/15536313085/job/43736065517#step:1:37)
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`.