### PR TITLE
workflow: give unique names to source and wheel artifacts

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -26,6 +26,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: source-artifact
         path: dist/*.tar.gz
 
 
@@ -59,8 +60,8 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: wheels-artifact
         path: ./wheelhouse/*.whl
-        overwrite: true
 
 
   upload_pypi:
@@ -69,9 +70,8 @@ jobs:
     needs: [build_bdist, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.4.2


### PR DESCRIPTION
Currently the wheel artifact overwrites the source artifact so we don't get a source distribution in pypi.

This change should allow us to remove the overwrite option and get both published.